### PR TITLE
Feat(BCE-25): load Chart Report Button

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,6 +11,10 @@ This can be bullet point or sentence format.
 If this is a change to the UI, include before and after screenshots to show the differences.
 If this is a new UI feature, include screenshots to show reviewers what it looks like. 
 
+### Before
+
+### After
+
 ## Test Proof
 If tests were added, include a screenshot of the tests all passing.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 JIRA: link to jira ticket
+
 ## Context:
 What is the ticket about and why are we doing this change.
 
@@ -6,12 +7,15 @@ What is the ticket about and why are we doing this change.
 What are the various changes and what other modules do those changes effect.
 This can be bullet point or sentence format.
 
-## Before and After UI (Required for UI-impacting PRs)
+## Before and After UI
 If this is a change to the UI, include before and after screenshots to show the differences.
 If this is a new UI feature, include screenshots to show reviewers what it looks like. 
 
-## Dev notes (Optional)
+## Test Proof
+If tests were added, include a screenshot of the tests all passing.
+
+## Dev notes
 - Specific technical changes that should be noted
-- 
-## Linked pull requests (Optional)
+
+## Linked pull requests
 - pull request link

--- a/client/src/components/NavB.js
+++ b/client/src/components/NavB.js
@@ -141,7 +141,7 @@ const NavB = (props) => {
                                             {" " + lngs[lng].nativeName}
                                         </NavDropdown.Item>
                                     )
-                                return
+                                return null
                             })}
                         </NavDropdown>
                     </Nav>
@@ -217,7 +217,7 @@ const NavB = (props) => {
                                                 {" " + lngs[lng].nativeName}
                                             </NavDropdown.Item>
                                         )
-                                    return
+                                    return null
                                 })}
                             </NavDropdown>
 

--- a/client/src/components/NavB.js
+++ b/client/src/components/NavB.js
@@ -123,25 +123,25 @@ const NavB = (props) => {
 
                     <Nav className="ms-auto">
                         <NavDropdown title={languageTitle} id="navbar-language-dropdown-login">
-                            {Object.keys(lngs).map((lng) => {
+                            {Object.keys(lngs).map((lng, i) => {
                                 if(lng === 'en' || lng === 'fr')
                                     return (
                                         <NavDropdown.Item
                                             id={lng}
-                                            key={lng}
+                                            key={i}
                                             onClick={() => {
                                                 i18n.changeLanguage(lng);
                                                 setLanguageTitle(lngs[lng].nativeName);
                                             }}>
-                                             {lng === 'en' 
+                                            {lng === 'en' 
                                             ? 
-                                            <img src={english} alt='english_flag' width='20px' />
+                                            <img key={i} src={english} alt='english_flag' width='20px' />
                                             : 
-                                            <img src={french} alt='french_flag' width='20px' />}
+                                            <img key={i} src={french} alt='french_flag' width='20px' />}
                                             {" " + lngs[lng].nativeName}
                                         </NavDropdown.Item>
                                     )
-                                return <></>
+                                return
                             })}
                         </NavDropdown>
                     </Nav>
@@ -199,25 +199,25 @@ const NavB = (props) => {
                             </Navbar.Text>
 
                             <NavDropdown title={languageTitle} id="navbar-language-dropdown">
-                                {Object.keys(lngs).map((lng) => {
+                                {Object.keys(lngs).map((lng, i) => {
                                     if(lng === 'en' || lng === 'fr')
                                         return (
                                             <NavDropdown.Item
                                                 id={lng}
-                                                key={lng}
+                                                key={i}
                                                 onClick={() => {
                                                     i18n.changeLanguage(lng);
                                                     setLanguageTitle(lngs[lng].nativeName);
                                                 }}>
                                                 {lng === 'en' 
                                                 ? 
-                                                <img src={english} alt='english_flag' width='20px' />
+                                                <img key={i} src={english} alt='english_flag' width='20px' />
                                                 : 
-                                                <img src={french} alt='french_flag' width='20px' />}
+                                                <img key={i} src={french} alt='french_flag' width='20px' />}
                                                 {" " + lngs[lng].nativeName}
                                             </NavDropdown.Item>
                                         )
-                                    return <></>
+                                    return
                                 })}
                             </NavDropdown>
 

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -51,8 +51,9 @@
     "dashboard":{
         "criteria":{
             "NamePlaceHolder":"Enter Chart Report Name",
-            "LoadChartButton":"Load Chart",
-            "SaveChartButton":"Save Chart",
+            "LoadChartButton":"Load",
+            "SaveChartButton":"Save",
+            "ResetChartButton": "Reset",
             "CreateNewChartButton":"Create Chart",
             "Title":"Chart Criteria",
             "Compare":"Compare selected employee with all employees",

--- a/client/src/locales/fr/translation.json
+++ b/client/src/locales/fr/translation.json
@@ -50,7 +50,7 @@
     },
     "dashboard": {
        "criteria": {
-         "SaveChartButton":"Sauvegarder le Graphique",
+         "SaveChartButton":"Sauvegarder",
          "CreateNewChartButton":"Créer un Graphique",
           "Title":"Filtres du graphique",
           "Compare":"Comparer l'employé selectionné avec tous les employés",
@@ -64,7 +64,8 @@
              "AccountType": "Type de compte"
           },
          "NamePlaceHolder": "Entrez le nom de votre Rapport Graphique",
-         "LoadChartButton": "Mettre à jour le Graphique",
+         "LoadChartButton": "Charger",
+         "ResetChartButton": "Réinitialiser",
          "StartDateLabel": "Mois de début",
          "EndDateLabel": "Mois de fin",
          "StartMonthExceedCurrentError": "Mois de début ne peut pas être après le mois actuel.",

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -372,6 +372,8 @@ const Dashboard = () => {
             chart()
             setIsFirstLoad(false)
         }
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [criteria]);
 
     const findCriteriaErrors = () => {

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -68,6 +68,7 @@ const Dashboard = () => {
     ];
 
     const [chartData, setChartData] = useState(fallbackChartData);
+    const [isFirstLoad, setIsFirstLoad] = useState(true)
     const [chartLoading, setChartLoading] = useState(false);
     const [confirmSaveActivated, setConfirmSaveActivated] = useState(false);
     const [chartSaved, setChartSaved] = useState(true);
@@ -85,7 +86,7 @@ const Dashboard = () => {
     const [employeeSelect, setEmployeeSelect] = useState([]);
     const [compareEmployeeChecked, setCompareEmployeeChecked] = useState(false);
 
-    const [criteria, setCriteria] = useState({
+    const emptyCriteria = {
         name: "",
         startYear: currentYear - 2,
         startMonth: 0,
@@ -106,11 +107,11 @@ const Dashboard = () => {
         clientType: "Any",
         ageOfAccount: "All",
         accountType: 'Receivables',
-    });
+    }
+    const [criteria, setCriteria] = useState(emptyCriteria);
+
     const [errors, setErrors] = useState({});
-
     const [yearList, setYearList] = useState([]);
-
     const [countries, setCountries] = useState([{ countryCode: "", countryLabel: "" }]);
 
     const setField = (field, value) => {
@@ -223,7 +224,6 @@ const Dashboard = () => {
     const chart = async (compare = false) => {
         setChartLoading(true);
         setChartData(fallbackChartData);
-        localStorage.setItem("dash_previous_criteria", JSON.stringify(criteria));
 
         let compareData = [];
         let arrayLength = 1;
@@ -360,7 +360,18 @@ const Dashboard = () => {
         countrySelectBox();
 
         createEmployeeCriteria();
-    };
+
+        const previouslyLoadedCriteriaStr = localStorage.getItem('dash_previous_criteria');
+        let previouslyLoadedCriteria = JSON.parse(previouslyLoadedCriteriaStr);
+        setCriteria(previouslyLoadedCriteria)       
+    }
+
+    useEffect(() => {
+        if(isFirstLoad && criteria !== emptyCriteria) {
+            chart()
+            setIsFirstLoad(false)
+        }
+    }, [criteria]);
 
     const findCriteriaErrors = () => {
         const { name, startYear, startMonth, endYear, endMonth } = criteria;
@@ -479,6 +490,11 @@ const Dashboard = () => {
         }
     };
 
+    const resetChartCriteria = () => {
+        localStorage.setItem("dash_previous_criteria", JSON.stringify(emptyCriteria))
+        setCriteria(emptyCriteria)
+    }
+
     // handle clicks to other pages when unsaved work on Chart Report
     const handleNavClick = async (whereTo) => {
         setPageToNavigateTo("/" + whereTo.split("/").at(-1));
@@ -505,9 +521,7 @@ const Dashboard = () => {
             navigate("/login");
         }
 
-        initCriteria();
-        chart();
-        
+        initCriteria()
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
@@ -796,6 +810,11 @@ const Dashboard = () => {
                                         variant='primary'>
                                         {saveChartButtonText}
                                     </Button>
+                                </Col>
+                            </Row>
+                            <Row>
+                                <Col>
+                                    <Button variant="secondary" className='w-100' onClick={resetChartCriteria}>Reset</Button>
                                 </Col>
                             </Row>
                         </div >

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -38,6 +38,7 @@ const Dashboard = () => {
     const chartReportNamePlaceHolder = t('dashboard.criteria.NamePlaceHolder');
     const loadChartButtonText = t('dashboard.criteria.LoadChartButton');
     const saveChartButtonText = t('dashboard.criteria.SaveChartButton');
+    const resetChartButtonText = t('dashboard.criteria.ResetChartButton');
     const chartTitle = t('dashboard.chart.Title');
     const chartXLabel = t('dashboard.chart.XAxisLabel');
     const chartYLabel = t('dashboard.chart.YAxisLabel');
@@ -814,7 +815,7 @@ const Dashboard = () => {
                             </Row>
                             <Row>
                                 <Col>
-                                    <Button variant="secondary" className='w-100' onClick={resetChartCriteria}>Reset</Button>
+                                    <Button variant="secondary" className='w-100' onClick={resetChartCriteria}>{resetChartButtonText}</Button>
                                 </Col>
                             </Row>
                         </div >

--- a/client/src/pages/Reports.js
+++ b/client/src/pages/Reports.js
@@ -465,7 +465,6 @@ const Reports = () => {
                                 </thead>
                                 <tbody>
                                     {chartReports.map((r, i) => {
-                                        console.log(r)
                                         return (
                                             <tr key={i} id={r.chartReportId}>
                                                 <td>{r.name}</td>

--- a/client/src/pages/Reports.js
+++ b/client/src/pages/Reports.js
@@ -477,7 +477,12 @@ const Reports = () => {
                                                 <td>{r.endDate.toString()}</td>
                                                 <td className="py-1">
                                                     <div className="d-flex justify-content-center">
-                                                        <Button id={r.chartReportId} className='mx-2 loadButtonChartReport' onClick={() => loadChart(r.name, r.startDate, r.endDate, {id: r.employee1Id, name: r.employee1Name}, {id: r.employee2Id, name: r.employee2Name}, {id: r.countryId, name: r.country}, r.clientType, r.ageOfAccount, r.accountType)}>Load</Button>
+                                                        <Button 
+                                                            id={r.chartReportId} 
+                                                            className='mx-2 loadButtonChartReport'
+                                                            onClick={() => loadChart(r.name, r.startDate, r.endDate, {id: r.employee1Id, name: r.employee1Name}, {id: r.employee2Id, name: r.employee2Name}, {id: r.countryId, name: r.country}, r.clientType, r.ageOfAccount, r.accountType)}>
+                                                                {t('dashboard.criteria.LoadChartButton')}
+                                                        </Button>
                                                         {pdfLoading
                                                             ?
                                                             r.chartReportId !== currentPdfLoading

--- a/client/src/pages/Reports.js
+++ b/client/src/pages/Reports.js
@@ -35,8 +35,11 @@ const Reports = () => {
         name: "",
         startDate: new Date(),
         endDate: new Date(),
-        employee1: "",
-        employee2: "",
+        employee1Id: "",
+        employee1Name: "",
+        employee2Id: "",
+        employee2Name: "",
+        countryId: "",
         country: "",
         clientType: "",
         ageOfAccount: "",
@@ -239,6 +242,38 @@ const Reports = () => {
             });
     };
 
+    const loadChart = (cName, startDate, endDate, emp1, emp2, country, clientType, aOAccount, accountType) => {
+        let sMonth = startDate.substring(5, 6)
+        let eMonth = endDate.substring(5, 6)
+        let sYear = startDate.substring(0, 4)
+        let eYear = endDate.substring(0, 4)
+
+        let chartCriteria = {
+            name: cName,
+            startYear: sYear,
+            startMonth: sMonth,
+            endYear: eYear,
+            endMonth: eMonth,
+            employee1: {
+                id: emp1.id,
+                name: emp1.name
+            },
+            employee2: {
+                id:  emp2.id,
+                name: emp2.name
+            },
+            country: {
+                id: country.id,
+                name: country.name
+            },
+            clientType: clientType,
+            ageOfAccount: aOAccount,
+            accountType: accountType,
+        }
+        localStorage.setItem("dash_previous_criteria", JSON.stringify(chartCriteria))
+        setTimeout(() => {navigate("/Dashboard")}, 1000);
+    }
+
     const handleDeleteChartReport = (id, chartReportName) => {
         setChartReportId(id);
         setChartReportName(chartReportName);
@@ -303,7 +338,7 @@ const Reports = () => {
                             <h4 className="text-center bg-light">{t('reports.reports.Title')}</h4>
                             <Table responsive hover id='reportTypesTable'>
                                 <thead className='bg-light'>
-                                    <tr key="0">
+                                    <tr key="-1">
                                         <th className='performance-table-columns'>{t('reports.reports.NameLabel')}</th>
                                         <th className='performance-table-columns'>{t('reports.reports.DateLabel')}</th>
                                         <th className='performance-table-columns'>{t('reports.reports.EmployeeLabel')}</th>
@@ -311,9 +346,9 @@ const Reports = () => {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {performanceReports.map((p) => {
+                                    {performanceReports.map((p, i) => {
                                         return (
-                                            <tr key={p.performanceReportId} id={p.performanceReportId}>
+                                            <tr key={i} id={p.performanceReportId}>
                                                 <td className='performance-table-columns'>{p.name}</td>
                                                 <td className='performance-table-columns'>{p.createdAt.toString()}</td>
                                                 <td className='performance-table-columns'>{p.recipient}</td>
@@ -355,9 +390,9 @@ const Reports = () => {
                                         id='reportTypeSelect'
                                         size="sm"
                                         aria-label="Default select example">
-                                        {reportTypes.map((t) => {
+                                        {reportTypes.map((t, i) => {
                                             return (
-                                                <option key={t.id} value={t.id}>
+                                                <option key={i} value={t.id}>
                                                     {t.name}
                                                 </option>)
                                         })}
@@ -429,9 +464,10 @@ const Reports = () => {
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    {chartReports.map(r => {
+                                    {chartReports.map((r, i) => {
+                                        console.log(r)
                                         return (
-                                            <tr key={r.chartReportId} id={r.chartReportId}>
+                                            <tr key={i} id={r.chartReportId}>
                                                 <td>{r.name}</td>
                                                 <td>{r.employee1Name}{r.employee2Name === null ? "" : ", " + r.employee2Name}</td>
                                                 <td>{r.clientType}</td>
@@ -442,6 +478,7 @@ const Reports = () => {
                                                 <td>{r.endDate.toString()}</td>
                                                 <td className="py-1">
                                                     <div className="d-flex justify-content-center">
+                                                        <Button id={r.chartReportId} className='mx-2 loadButtonChartReport' onClick={() => loadChart(r.name, r.startDate, r.endDate, {id: r.employee1Id, name: r.employee1Name}, {id: r.employee2Id, name: r.employee2Name}, {id: r.countryId, name: r.country}, r.clientType, r.ageOfAccount, r.accountType)}>Load</Button>
                                                         {pdfLoading
                                                             ?
                                                             r.chartReportId !== currentPdfLoading

--- a/client/src/styles/reportsPage.css
+++ b/client/src/styles/reportsPage.css
@@ -61,6 +61,10 @@ h4 {
     padding-bottom: 0.3rem;
 }
 
+.loadButtonChartReport {
+    height: 36px;
+}
+
 @media all and (max-width: 1000px) {
     .container-reportsPage {
       flex-direction: column;


### PR DESCRIPTION
JIRA: [BCE-25](https://champlainsaintlambert.atlassian.net/browse/BCE-25)
## Context:
Added a button on the chart reports table in the Reports page to load the chart reports directly on the dashboard.

## Changes
- Added button 'Load' on the chart report table
- Added reset button on dashboard
- fixed map and key issues on navbar and reports

## Before and After UI (Required for UI-impacting PRs)
### Dashboard Page
#### Before
![before dashboard](https://user-images.githubusercontent.com/70593499/156665513-e6b3d5cd-bdd7-4e39-aaa2-59942630cb49.png)

#### After
![after dashboard](https://user-images.githubusercontent.com/70593499/156665524-39c73e0c-589b-40fa-ad75-abc649fbd59b.png)

### Reports Page
#### Before
![before report](https://user-images.githubusercontent.com/70593499/156665521-2a1faa4f-cca7-40cd-bf04-d596c4191ec7.png)

#### After
![after report](https://user-images.githubusercontent.com/70593499/156665537-addb6c8c-61b8-4d2d-92bb-539efe740e68.png)

